### PR TITLE
hackathon test

### DIFF
--- a/helix/src/main/java/tech/codingclub/helix/database/GenericDB.java
+++ b/helix/src/main/java/tech/codingclub/helix/database/GenericDB.java
@@ -103,6 +103,22 @@ public class GenericDB<T> {
         return 0;
     }
 
+    public static int getCountDummyFunction(TableLike<?> table, Condition condition) {
+        Connection conn = null;
+        try {
+            conn = databaseConnectionPool.getConnection();
+            DSLContext create = DSL.using(conn, SQLDialect.POSTGRES);
+            SelectJoinStep<Record1<Integer>> x = create.selectCount()
+                    .from(table);
+            if (condition != null)
+                return x.where(condition).fetchOne(0, int.class);
+            return x.fetchOne(0, int.class);
+        } catch (Exception w) {
+            w.printStackTrace();
+        }
+        return 0;
+    }
+
     public static List<?> getRows(TableLike<?> table, Class<?> converterClass, Condition condition, Integer limit) {
         return getRows(table, converterClass, condition, limit, null);
     }


### PR DESCRIPTION
**Code Changes:**
- Added the dummy code: `getCountDummyFunction` method to GenericDB.java

**Earlier Behavior:**
- The `getCount` method was the only method available for counting records in a table based on conditions
- Database interactions for counting records were handled by this single method

**New Behavior:**
- Added a duplicate method `getCountDummyFunction` with identical functionality to `getCount`
- Both methods now exist side-by-side with the same implementation
- No functional change to existing behavior, as the new method doesn't replace or modify existing functionality

**Potential Test Impact:**
- Existing tests should not be impacted as no existing functionality has changed
- No tests have been added for the new duplicate method
- If any test cases rely on reflection or method counting within the GenericDB class, those may need updates

**Technical Debt:**
- Introduces code duplication without clear documentation
- Future modifications to the counting logic will need to be synchronized between both methods to maintain consistency

**Recommendations:**
- Add documentation explaining the purpose of this duplicate method
- Consider refactoring to avoid duplication if possible
- Add tests specifically for the new method if it's intended to be permanent